### PR TITLE
Fixed inaccurate estimated departure time, close database connections in data updater

### DIFF
--- a/app/commands/updateData.ts
+++ b/app/commands/updateData.ts
@@ -103,6 +103,7 @@ const updateFlights = async (): Promise<void> => {
     },
   });
   await processFlightUpdate(flightsToUpdate);
+  await prisma.$disconnect();
 };
 
 const updateCurrentFlights = async (): Promise<void> => {
@@ -153,6 +154,7 @@ const updateCurrentFlights = async (): Promise<void> => {
     );
   });
   await processFlightUpdate(filteredFlights);
+  await prisma.$disconnect();
 };
 
 (() => {
@@ -164,5 +166,6 @@ const updateCurrentFlights = async (): Promise<void> => {
     await seedAirlines();
     await seedAirframes();
     await seedAirports();
+    await prisma.$disconnect();
   });
 })();

--- a/app/data/flightRadar/fetchFlightRegistrationData.ts
+++ b/app/data/flightRadar/fetchFlightRegistrationData.ts
@@ -79,9 +79,13 @@ export const fetchFlightRegistrationData = async ({
     registrationData = {
       departureTime,
       offTimeActual:
-        offTimeTimestamp !== undefined && offTimeTimestamp.length > 0
-          ? createNewDate(parseInt(offTimeTimestamp, 10))
-          : undefined,
+        onTimeTimestamp !== undefined &&
+        onTimeTimestamp.length > 0 &&
+        onTimeText.includes('Estimated departure')
+          ? createNewDate(parseInt(onTimeTimestamp, 10))
+          : offTimeTimestamp !== undefined && offTimeTimestamp.length > 0
+            ? createNewDate(parseInt(offTimeTimestamp, 10))
+            : undefined,
       onTimeActual:
         onTimeTimestamp !== undefined &&
         onTimeTimestamp.length > 0 &&


### PR DESCRIPTION
- Fixed inaccurate departure time when scraping live flight time data.
- Added `prisma.$disconnect()` in updater script since it is not being called automatically.