### PR TITLE
Disabled flightradar as datasource, fetch tail numbers from flightstats

### DIFF
--- a/app/data/flightRadar/fetchFlightRadarData.ts
+++ b/app/data/flightRadar/fetchFlightRadarData.ts
@@ -1,4 +1,4 @@
-import type { Airline, FlightRadarStatus } from '@prisma/client';
+import type { Airline } from '@prisma/client';
 import axios from 'axios';
 import { load } from 'cheerio';
 import { formatInTimeZone } from 'date-fns-tz';
@@ -265,7 +265,7 @@ export const fetchFlightRadarData = async ({
       .find('.btn-playback')
       .text()
       .trim();
-    let flightStatus: FlightRadarStatus | null = null;
+    let flightStatus: FlightRadarData['flightStatus'] | null = null;
     let diversionIata: string | null = null;
     if (onTimeCell.text().includes('Diverted to')) {
       const airport = onTimeCell.find('a').eq(0).text().trim();

--- a/app/data/flightRadar/types.ts
+++ b/app/data/flightRadar/types.ts
@@ -1,5 +1,3 @@
-import type { FlightRadarStatus } from '@prisma/client';
-
 export interface FlightRadarData {
   departureTime: Date;
   departureAirportIATA: string;
@@ -8,7 +6,14 @@ export interface FlightRadarData {
   onTimeActual: Date | undefined;
   aircraftTypeCode: string;
   registration: string | null | undefined;
-  flightStatus: FlightRadarStatus | null;
+  flightStatus:
+    | 'SCHEDULED'
+    | 'DEPARTED_TAXIING'
+    | 'EN_ROUTE'
+    | 'LANDED_TAXIING'
+    | 'ARRIVED'
+    | 'CANCELED'
+    | null;
   diversionIata: string | null;
 }
 

--- a/app/data/flightStats/types.ts
+++ b/app/data/flightStats/types.ts
@@ -125,7 +125,7 @@ export interface FlightStatsFlight {
       flightId: number;
       carrierFsCode: string;
       flightNumber: string;
-      tailNumber: string;
+      tailNumber: string | null;
       callsign: string;
       departureAirportFsCode: string;
       arrivalAirportFsCode: string;

--- a/app/data/planeMapper/fetchPlaneMapperData.ts
+++ b/app/data/planeMapper/fetchPlaneMapperData.ts
@@ -1,0 +1,29 @@
+import type { Airline } from '@prisma/client';
+import axios from 'axios';
+import { load } from 'cheerio';
+
+import { HEADERS } from '../constants';
+import type { FlightWithDataAirport } from '../types';
+
+export interface FetchPlaneMapperDataParams {
+  airline: Airline;
+  arrivalAirport: FlightWithDataAirport;
+  departureAirport: FlightWithDataAirport;
+  flightNumber: number;
+  isoDate: string;
+}
+
+export const fetchPlaneMapperData = async ({
+  airline,
+  arrivalAirport,
+  departureAirport,
+  flightNumber,
+  isoDate,
+}: FetchPlaneMapperDataParams): Promise<void> => {
+  const url = `https://www.planemapper.com/flights/${
+    airline.iata ?? airline.icao
+  }${flightNumber}`;
+  const response = await axios.get<string>(url, { headers: HEADERS });
+  const $ = load(response.data);
+  console.log($);
+};

--- a/app/data/planeMapper/index.ts
+++ b/app/data/planeMapper/index.ts
@@ -1,0 +1,1 @@
+export * from './fetchPlaneMapperData';

--- a/app/routes/flightData.ts
+++ b/app/routes/flightData.ts
@@ -24,11 +24,14 @@ export const flightDataRouter = router({
     .input(searchFlightDataSchema)
     .query(async ({ input }) => {
       const { airline, flightNumber, outDateISO } = input;
-      const flights = await fetchFlightRadarDataByFlightNumber({
-        airline,
-        flightNumber,
-        isoDate: outDateISO,
-      });
+      const flights =
+        process.env.FLIGHT_TRACKING_DATASOURCE === 'flightradar'
+          ? await fetchFlightRadarDataByFlightNumber({
+              airline,
+              flightNumber,
+              isoDate: outDateISO,
+            })
+          : [];
       const flightData: FlightSearchDataResult[] = flights.map(
         (flight, index) => {
           const duration = getDurationMinutes({

--- a/app/routes/flights.ts
+++ b/app/routes/flights.ts
@@ -394,7 +394,6 @@ export const flightsRouter = router({
       }>(
         (acc, flight) => {
           const timestamps = getFlightTimestamps({
-            flightRadarStatus: flight.flightRadarStatus,
             departureTimeZone: flight.departureAirport.timeZone,
             arrivalTimeZone: flight.arrivalAirport.timeZone,
             duration: flight.duration,
@@ -541,8 +540,7 @@ export const flightsRouter = router({
       for (const result of flightResults) {
         const flight = transformFlightData(result);
         const flightState =
-          flight.flightStatus === 'SCHEDULED' ||
-          flight.flightStatus === 'CANCELED'
+          flight.flightStatus === 'SCHEDULED'
             ? 'UPCOMING'
             : flight.flightStatus === 'ARRIVED'
               ? 'COMPLETED'
@@ -743,7 +741,6 @@ export const flightsRouter = router({
         inTime,
         inTimeActual: flightDataChanged ? null : undefined,
         duration,
-        flightRadarStatus: flightDataChanged ? null : undefined,
         departureGate: flightDataChanged ? null : undefined,
         departureTerminal: flightDataChanged ? null : undefined,
         arrivalBaggage: flightDataChanged ? null : undefined,

--- a/app/utils/flighttime.ts
+++ b/app/utils/flighttime.ts
@@ -1,4 +1,4 @@
-import { type Airport, type FlightRadarStatus } from '@prisma/client';
+import { type Airport } from '@prisma/client';
 import { add, isBefore, isFuture } from 'date-fns';
 import { formatInTimeZone, fromZonedTime } from 'date-fns-tz';
 
@@ -29,7 +29,6 @@ export interface FlightTimesInput {
 }
 
 export interface FlightTimestampsInput {
-  flightRadarStatus?: FlightRadarStatus | null;
   departureTimeZone: string;
   arrivalTimeZone: string;
   duration: number;
@@ -135,7 +134,6 @@ export const getFlightTimes = ({
 };
 
 export const getFlightTimestamps = ({
-  flightRadarStatus,
   departureTimeZone,
   arrivalTimeZone,
   duration,
@@ -159,21 +157,17 @@ export const getFlightTimestamps = ({
         })
       : null;
   const departureDelayStatus =
-    flightRadarStatus === 'CANCELED'
-      ? 'canceled'
-      : departureDelay !== null && departureDelay > 60
-        ? 'severe'
-        : departureDelay !== null && departureDelay > 15
-          ? 'moderate'
-          : 'none';
+    departureDelay !== null && departureDelay >= 60
+      ? 'severe'
+      : departureDelay !== null && departureDelay >= 15
+        ? 'moderate'
+        : 'none';
   const arrivalDelayStatus =
-    flightRadarStatus === 'CANCELED'
-      ? 'canceled'
-      : arrivalDelay !== null && arrivalDelay > 60
-        ? 'severe'
-        : arrivalDelay !== null && arrivalDelay > 15
-          ? 'moderate'
-          : 'none';
+    arrivalDelay !== null && arrivalDelay >= 60
+      ? 'severe'
+      : arrivalDelay !== null && arrivalDelay >= 15
+        ? 'moderate'
+        : 'none';
   return {
     durationString: getDurationString(duration),
     durationStringAbbreviated: getDurationString(duration, true),

--- a/app/utils/statistics.ts
+++ b/app/utils/statistics.ts
@@ -33,7 +33,7 @@ export const getOnTimeStreak = (
             end: flight.inTimeActual,
           })
         : 0;
-      if (arrivalDelay > 15) {
+      if (arrivalDelay >= 15) {
         break;
       }
       onTimeStreak++;

--- a/prisma/migrations/20250305074638_removed_flight_radar_status_column/migration.sql
+++ b/prisma/migrations/20250305074638_removed_flight_radar_status_column/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `flightRadarStatus` on the `flight` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "flight" DROP COLUMN "flightRadarStatus";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -132,7 +132,6 @@ model Flight {
   offTimeActual      DateTime?
   onTimeActual       DateTime?
   outTimeActual      DateTime?
-  flightRadarStatus  FlightRadarStatus?
   arrivalBaggage     String?
   arrivalGate        String?
   arrivalTerminal    String?

--- a/resources/pages/Home/FlightRow.tsx
+++ b/resources/pages/Home/FlightRow.tsx
@@ -195,19 +195,12 @@ export const FlightRow = ({
           >
             <span className="text-sm">{flight.flightStatusText}</span>
             <span className="flex justify-end gap-1 text-xs">
-              {flight.flightRadarStatus === 'CANCELED' ? (
-                'Canceled'
-              ) : (
+              {flight.delayStatus !== 'none' ? (
                 <>
-                  {flight.delayStatus !== 'none' ? (
-                    <>
-                      Delayed{' '}
-                      <span className="text-nowrap">{flight.delay}</span>
-                    </>
-                  ) : (
-                    'On Time'
-                  )}
+                  Delayed <span className="text-nowrap">{flight.delay}</span>
                 </>
+              ) : (
+                'On Time'
               )}
             </span>
           </div>

--- a/resources/pages/Home/FollowingMap.tsx
+++ b/resources/pages/Home/FollowingMap.tsx
@@ -241,19 +241,17 @@ export const FollowingMap = (): JSX.Element => {
                     estimatedLocation,
                     estimatedHeading,
                     flightState,
-                    flightRadarStatus,
+                    flightStatus,
                     tracklog,
                     waypoints,
                   },
                   index,
                 ) => {
-                  const isCurrentFlight =
-                    flightRadarStatus !== null &&
-                    [
-                      'DEPARTED_TAXIING',
-                      'EN_ROUTE',
-                      'ARRIVED_TAXIING',
-                    ].includes(flightRadarStatus);
+                  const isCurrentFlight = [
+                    'DEPARTED_TAXIING',
+                    'EN_ROUTE',
+                    'ARRIVED_TAXIING',
+                  ].includes(flightStatus);
                   const isFocused = isSelected || isHover || isCurrentFlight;
                   let lastAltitude: number | null = null;
                   return (
@@ -321,7 +319,7 @@ export const FollowingMap = (): JSX.Element => {
                           />
                         );
                       }) ?? null}
-                      {flightRadarStatus !== 'ARRIVED' ? (
+                      {flightStatus !== 'ARRIVED' ? (
                         <PolylineF
                           visible
                           key={index}

--- a/resources/pages/Profile/components/Flights/ActiveFlightCard.tsx
+++ b/resources/pages/Profile/components/Flights/ActiveFlightCard.tsx
@@ -277,25 +277,23 @@ export const ActiveFlightCard = (): JSX.Element | null => {
                 </div>
               </div>
               <div className="flex flex-col items-center justify-center gap-1">
-                {data.flightRadarStatus !== 'CANCELED' ? (
-                  <div className="text-xs italic opacity-75 sm:text-sm">
-                    {data.progress === 0 && data.flightProgress === 0
-                      ? `Departs in ${data.durationToDepartureString}`
-                      : null}
-                    {data.progress > 0 && data.flightProgress === 0
-                      ? `Taking off in ${data.durationToTakeoffString}`
-                      : null}
-                    {data.flightProgress > 0 && data.flightProgress < 1
-                      ? `Landing in ${data.durationToLandingString}`
-                      : null}
-                    {data.flightProgress === 1 && data.progress < 1
-                      ? `Arriving in ${data.durationToArrivalString}`
-                      : null}
-                    {data.progress === 1 && data.flightProgress === 1
-                      ? `Arrived ${data.durationToArrivalString} ago`
-                      : null}
-                  </div>
-                ) : null}
+                <div className="text-xs italic opacity-75 sm:text-sm">
+                  {data.progress === 0 && data.flightProgress === 0
+                    ? `Departs in ${data.durationToDepartureString}`
+                    : null}
+                  {data.progress > 0 && data.flightProgress === 0
+                    ? `Taking off in ${data.durationToTakeoffString}`
+                    : null}
+                  {data.flightProgress > 0 && data.flightProgress < 1
+                    ? `Landing in ${data.durationToLandingString}`
+                    : null}
+                  {data.flightProgress === 1 && data.progress < 1
+                    ? `Arriving in ${data.durationToArrivalString}`
+                    : null}
+                  {data.progress === 1 && data.flightProgress === 1
+                    ? `Arrived ${data.durationToArrivalString} ago`
+                    : null}
+                </div>
                 {data.arrivalBaggage !== null ? (
                   <div
                     className={classNames(

--- a/resources/pages/Profile/components/Map/GoogleMap.tsx
+++ b/resources/pages/Profile/components/Map/GoogleMap.tsx
@@ -270,10 +270,9 @@ export const GoogleMap = ({
         )}
       />
       {mapMode === 'routes' &&
-      currentFlight?.flightRadarStatus !== undefined &&
-      currentFlight.flightRadarStatus !== null &&
+      currentFlight?.flightStatus !== undefined &&
       ['DEPARTED_TAXIING', 'EN_ROUTE', 'ARRIVED_TAXIING'].includes(
-        currentFlight.flightRadarStatus,
+        currentFlight.flightStatus,
       ) ? (
         <OverlayViewF
           position={{

--- a/resources/pages/Profile/components/Map/MapCard.tsx
+++ b/resources/pages/Profile/components/Map/MapCard.tsx
@@ -122,7 +122,7 @@ export const MapCard = ({
             lng: currentFlightData.estimatedLocation.lng,
             heading: currentFlightData.estimatedHeading,
             delayStatus: currentFlightData.delayStatus,
-            flightRadarStatus: currentFlightData.flightRadarStatus,
+            flightStatus: currentFlightData.flightStatus,
             callsign: `${currentFlightData.airline?.icao}${currentFlightData.flightNumber}`,
             tracklog: currentFlightData.tracklog,
             waypoints: currentFlightData.waypoints,

--- a/resources/pages/Profile/components/Map/types.ts
+++ b/resources/pages/Profile/components/Map/types.ts
@@ -1,13 +1,14 @@
-import type { Airport, FlightRadarStatus } from '@prisma/client';
+import type { Airport } from '@prisma/client';
 
 import type { TracklogItem } from '../../../../../app/data/types';
 import { type FlightsRouterOutput } from '../../../../../app/routes/flights';
+import { type TransformFlightDataResult } from '../../../../../app/utils';
 import type { FlightDelayStatus } from '../../../../common/types';
 
 export interface MapFlight extends google.maps.LatLngLiteral {
   heading: number;
   delayStatus: FlightDelayStatus;
-  flightRadarStatus: FlightRadarStatus | null;
+  flightStatus: TransformFlightDataResult['flightStatus'];
   callsign: string;
   tracklog: TracklogItem[] | undefined;
   waypoints: Array<[number, number]> | undefined;


### PR DESCRIPTION
- Disabled FlightRadar24 as datasource for tail numbers and takeoff/landing times.
- Made changes to extract aircraft tail number data from FlightStats
- Changed cutoff for "late" flights from more than 15 minutes to 15 minutes or more